### PR TITLE
Added detection of steam mods

### DIFF
--- a/src/AloViewer.vcxproj
+++ b/src/AloViewer.vcxproj
@@ -123,7 +123,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(SolutionDir)libs\expat-2.2.0\include;$(SolutionDir)libs\dx9\Include;$(SolutionDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WIN32_WINNT=0x600;WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;XML_STATIC;XML_UNICODE_WCHAR_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />

--- a/src/Games.h
+++ b/src/Games.h
@@ -20,6 +20,7 @@ struct GameMod
 {
     GameID       m_game;
     std::wstring m_mod;
+    bool         m_isSteamMod;
 
     // Operators
     bool operator == (const GameMod& rhs) const {
@@ -44,6 +45,8 @@ struct GameMod
     // Constructors
     GameMod(GameID game = GID_UNKNOWN) : m_game(game) {}
     GameMod(GameID game, const std::wstring& mod) : m_game(game), m_mod(mod) {}
+    GameMod(GameID game, const std::wstring& mod, bool isSteamMod) : m_game(game), m_mod(mod), m_isSteamMod(isSteamMod) {}
+
 };
 
 #endif

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -262,12 +262,52 @@ GameMod Config::GetDefaultGameMod()
 
 void Config::SetDefaultGameMod(const GameMod& gm)
 {
-	HKEY hKey;
+    HKEY hKey;
     const wstring path = wstring(REGISTRY_BASE_PATH) + L"\\Settings";
-	if (RegOpenKeyEx(HKEY_CURRENT_USER, path.c_str(), 0, KEY_WRITE, &hKey) == ERROR_SUCCESS)
-	{
+    if (RegOpenKeyEx(HKEY_CURRENT_USER, path.c_str(), 0, KEY_WRITE, &hKey) == ERROR_SUCCESS)
+    {
         WriteInteger(hKey, L"GameMod_Game", gm.m_game);
         WriteString(hKey, L"GameMod_Mod", gm.m_mod);
         RegCloseKey(hKey);
     }
 }
+
+//Simply check if steam is installed by checking if the steam path exists
+bool Config::IsSteamInstalled() {
+    HKEY hKey;
+    const wstring path = wstring(REGISTRY_STEAM_PATH);
+    wstring steamPath = L"";
+    if (RegOpenKeyEx(HKEY_CURRENT_USER, path.c_str(), 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    {
+        steamPath = ReadString(hKey, L"SteamPath");
+        RegCloseKey(hKey);
+    }
+    return !steamPath.empty();
+
+}
+
+//Check if EaW or FoC are the steam gold pack
+bool Config::IsSteamVersion(GameID game) {
+    if (game != GID_EAW && game != GID_EAW_FOC) { //Only EAW & FOC are on steam!
+        return false;
+    }
+
+    HKEY hKey;
+    const wstring path = wstring(REGISTRY_STEAM_PATH)  + L"\\Apps\\32470"; //Steamapp number for EaW & FoC Goldpack
+    int eawGoldPackInstalled{};
+    if (RegOpenKeyEx(HKEY_CURRENT_USER, path.c_str(), 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    {
+        eawGoldPackInstalled = ReadInteger(hKey, L"Installed", 0);
+        RegCloseKey(hKey);
+    }
+    return eawGoldPackInstalled == 1;
+}
+
+std::wstring Config::GetSteamWorkshopDir(GameID game, wstring gamepath){
+    if (game != GID_EAW && game != GID_EAW_FOC) { //Only EAW & FOC are on steam!
+        return L"";
+    }
+
+    return gamepath + L"\\..\\..\\..\\workshop\\content\\32470";
+}
+

--- a/src/config.h
+++ b/src/config.h
@@ -17,6 +17,7 @@ static const wchar_t* WINDOW_TITLE  = L"Alamo Object Viewer";
 // Base path in HKEY_CURRENT_USER for this application
 static const wchar_t* REGISTRY_BASE_PATH = L"Software\\AloViewer";
 
+
 // Minimum dimension for the application window
 static const int MIN_APPLICATION_WIDTH  = 700;
 static const int MIN_APPLICATION_HEIGHT = 550;
@@ -55,5 +56,17 @@ void AddToHistory(const std::wstring& name);
 // Get and set the default game mod
 GameMod GetDefaultGameMod();
 void SetDefaultGameMod(const GameMod& mode);
+
+//STEAM
+
+// Base steam registry path
+static const wchar_t* REGISTRY_STEAM_PATH = L"Software\\Valve\\Steam";
+
+bool IsSteamInstalled();
+
+bool IsSteamVersion(GameID game);
+
+std::wstring GetSteamWorkshopDir(GameID game, std::wstring gamepath);
+
 }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -618,7 +618,16 @@ static void InitializeGameMenu(ApplicationInfo* info)
             id = q.first->second.first++;
             info->gameModLookup[id] = p;
             p->second.menuitem = id;
-            AppendMenu(hGame, MF_ENABLED | MF_STRING, id, p->first.m_mod.c_str());
+
+            wstring itemName;
+            if (p->first.m_isSteamMod) {
+                itemName = L"SteamMod: " + p->first.m_mod;
+            }
+            else {
+                itemName = p->first.m_mod.c_str();
+            }
+
+            AppendMenu(hGame, MF_ENABLED | MF_STRING, id, itemName.c_str());
         }
     }
     


### PR DESCRIPTION
Hey there!

I added a feature where the AloViewer now can find steam mods, which can then be selected the in the mod selection menu.
Only issue: It cannot differentiate between EaW and FoC mods since they all come under the same workshop folder for the Gold Pack.